### PR TITLE
Add automated asset test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# AI Impact Website
+
+This project includes a simple HTML page with images. Automated tests are
+provided to ensure that all image files referenced in `index.html` exist in the
+repository.
+
+## Running the tests
+
+Install `pytest` if it is not already available and run the tests from the
+project root:
+
+```bash
+pytest
+```
+
+The tests do not require network access and only depend on Python's standard
+library.

--- a/tests/test_assets.py
+++ b/tests/test_assets.py
@@ -1,0 +1,41 @@
+import os
+from urllib.parse import quote
+from html.parser import HTMLParser
+
+
+class ImgSrcParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.srcs = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() == "img":
+            for attr, value in attrs:
+                if attr.lower() == "src":
+                    self.srcs.append(value)
+
+
+def get_img_sources(html_path):
+    parser = ImgSrcParser()
+    with open(html_path, "r", encoding="utf-8") as f:
+        parser.feed(f.read())
+    return parser.srcs
+
+
+def test_all_image_files_exist():
+    project_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    html_file = os.path.join(project_root, "index.html")
+    srcs = get_img_sources(html_file)
+
+    missing = []
+    for src in srcs:
+        # remove leading slashes and known prefix
+        if src.startswith("/mnt/data/"):
+            src = src[len("/mnt/data/") :]
+        src = src.lstrip("/")
+        encoded_src = quote(src, safe="")
+        file_path = os.path.join(project_root, encoded_src)
+        if not os.path.exists(file_path):
+            missing.append(src)
+
+    assert not missing, f"Missing files: {missing}"


### PR DESCRIPTION
## Summary
- add simple pytest in `tests/` to ensure images referenced by `index.html` exist
- document how to run the tests in `README.md`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68412332581c8326814a1181ae1cff18